### PR TITLE
Add inline doc into FindMKL.cmake

### DIFF
--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -104,7 +104,7 @@ else()
     if (WIN32)
         set(MKL_LINK_TOOL ${MKL_LINK_TOOL}.exe)
     endif()
-    
+
     # check that the tools exists or quit
     if (NOT EXISTS "${MKL_LINK_TOOL}")
         message(FATAL_ERROR "cannot find MKL tool: ${MKL_LINK_TOOL}")
@@ -232,7 +232,7 @@ else()
 
     else() # UNIX and macOS
         # remove unwanted break
-		string(REGEX REPLACE "\n" "" MKL_LIBS ${MKL_LIBS}) 
+		string(REGEX REPLACE "\n" "" MKL_LIBS ${MKL_LIBS})
         if (MKL_LINK_TOOL_COMMAND MATCHES "static")
             string(REPLACE "$(MKLROOT)" "${MKL_ROOT_DIR}" MKL_LIBRARIES ${MKL_LIBS})
             # hack for lin with libiomp5.a

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -1,18 +1,31 @@
-# - Try to find the Intel Math Kernel Library
-# Once done this will define
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#.rst:
+# FindMKL
+# -------
 #
-#  MKL_FOUND - system has MKL
-#  MKL_ROOT_DIR - path to the MKL base directory
-#  MKL_INCLUDE_DIR - the MKL include directory
-#  MKL_LIBRARIES - MKL libraries
-#  MKL_LIBRARY_DIR - MKL library dir (for dlls!)
+# Find a Intel® Math Kernel Library (Intel® MKL) installation and provide
+# all necessary variables and macros to compile software for it.
+#
+# MKLROOT is required in your system
 #
 # we use mkl_link_tool to get the library needed depending on variables
 # There are few sets of libraries:
+#
 # Array indexes modes:
+#
+# ::
+#
 # LP - 32 bit indexes of arrays
 # ILP - 64 bit indexes of arrays
+#
+#
+#
 # Threading:
+#
+# ::
+#
 # SEQUENTIAL - no threading
 # INTEL - Intel threading library
 # GNU - GNU threading library
@@ -21,6 +34,48 @@
 # INTEL - Intel MPI library
 # OPEN - Open MPI library
 # SGI - SGI MPT Library
+#
+#
+#
+#
+# The following are set after the configuration is done:
+#
+# ::
+#
+#  MKL_FOUND        -  system has MKL
+#  MKL_ROOT_DIR     -  path to the MKL base directory
+#  MKL_INCLUDE_DIR  -  the MKL include directory
+#  MKL_LIBRARIES    -  MKL libraries
+#  MKL_LIBRARY_DIR  -  MKL library dir (for dlls!)
+#
+#
+#
+# Sample usage:
+#
+# If MKL is required (i.e., not an optional part):
+#
+# ::
+#
+#    find_package(MKL REQUIRED)
+#    if (MKL_FOUND)
+#        include_directories(${MKL_INCLUDE_DIR})
+#        # and for each of your dependent executable/library targets:
+#        target_link_libraries(<YourTarget> ${MKL_LIBRARIES})
+#    endif()
+
+
+# NOTES
+#
+# If you want to use the module and your build type is not supported
+# out-of-the-box, please contact me to exchange information on how
+# your system is setup and I'll try to add support for it.
+#
+# AUTHOR
+#
+# Joan MASSICH (joan.massich-vall.AT.inria.fr).
+# Alexandre GRAMFORT (Alexandre.Gramfort.AT.inria.fr)
+# Théodore PAPADOPOULO (papadop.AT.inria.fr)
+
 
 set(CMAKE_FIND_DEBUG_MODE 1)
 


### PR DESCRIPTION
Add documentation to render proper in [cmake find_packages index](https://cmake.org/cmake/help/latest/manual/cmake-modules.7.html) in case it needs to be integrated. 

I think we should think about which is the best way to expose MKL options (we can take inspiration from FindwxWidgets or anyother package)

We can enter this PR as is, and retake it afterwards.
cc: @agramfort 