### PR TITLE
Fix link tool path for MKL 2020.1.217 and newer

### DIFF
--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -99,7 +99,12 @@ else()
     set(MKL_INCLUDE_DIR ${MKL_ROOT_DIR}/include)
 
     # set arguments to call the MKL provided tool for linking
-    set(MKL_LINK_TOOL ${MKL_ROOT_DIR}/tools/mkl_link_tool)
+    if (EXISTS "${MKL_ROOT_DIR}/bin/mkl_link_tool")
+      # this path is used by MKL 2020.1.217 and newer
+      set(MKL_LINK_TOOL "${MKL_ROOT_DIR}/bin/mkl_link_tool")
+    elseif (EXISTS "${MKL_ROOT_DIR}/tools/mkl_link_tool")
+      set(MKL_LINK_TOOL "${MKL_ROOT_DIR}/tools/mkl_link_tool")
+    endif()
 
     if (WIN32)
         set(MKL_LINK_TOOL ${MKL_LINK_TOOL}.exe)


### PR DESCRIPTION
Before MKL version 2020.1.217, the `mkl_link_tool` executable was provided in directory `${MKL_ROOT_DIR}/tools`.  Starting from MKL version 2020.1.217, the executable is instead provided in directory `${MKL_ROOT_DIR}/bin`.  This pull request updates FindMKL to search for the executable in both the new and old locations.